### PR TITLE
Add PSR-4 autoloading for tests and update test namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "I4code\\JaApi\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "prefer-stable": true,
     "require": {
         "nyholm/psr7": "^1.2",

--- a/tests/integration/DiServiceTest.php
+++ b/tests/integration/DiServiceTest.php
@@ -1,16 +1,15 @@
 <?php
 declare(strict_types=1);
 
-include_once 'tests/assets/classes/TestController.php';
-include_once 'tests/assets/classes/TestClass.php';
+namespace Tests\Integration;
 
 use I4code\JaApi\Container as DI;
 use I4code\JaApi\ServerRequestFactory;
 use I4code\JaApi\Service;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use Tests\Assets\Classes\TestController;
 use Tests\Assets\Classes\TestClass;
+use Tests\Assets\Classes\TestController;
 
 class DiServiceTest extends TestCase
 {

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -1,12 +1,14 @@
 <?php
 declare(strict_types=1);
 
+namespace Tests\Integration;
+
+use I4code\JaApi\Controllers\DefaultController;
 use I4code\JaApi\Middlewares\JsonMiddleware;
-use PHPUnit\Framework\TestCase;
 use I4code\JaApi\ServerRequestFactory;
 use I4code\JaApi\Service;
-use I4code\JaApi\Controllers\DefaultController;
 use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 
 class IntegrationTest extends TestCase

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -1,8 +1,9 @@
 <?php
 declare(strict_types=1);
 
-include_once 'tests/assets/classes/TestClass.php';
+namespace Tests\Unit;
 
+use Closure;
 use I4code\JaApi\Container;
 use PHPUnit\Framework\TestCase;
 use Tests\Assets\Classes\TestClass;

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -1,5 +1,7 @@
 <?php
+declare(strict_types=1);
 
+namespace Tests\Unit;
 
 use I4code\JaApi\Factory;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/JsonEncoderTest.php
+++ b/tests/unit/JsonEncoderTest.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 
+namespace Tests\Unit;
+
+use I4code\JaApi\JsonEncoder;
 use PHPUnit\Framework\TestCase;
 
 class JsonEncoderTest extends TestCase
@@ -8,8 +11,8 @@ class JsonEncoderTest extends TestCase
 
     public function testConstructor()
     {
-        $encoder = new \I4code\JaApi\JsonEncoder();
-        $this->assertInstanceOf(\I4code\JaApi\JsonEncoder::class, $encoder);
+        $encoder = new JsonEncoder();
+        $this->assertInstanceOf(JsonEncoder::class, $encoder);
     }
 
     public function testDecode()
@@ -19,7 +22,7 @@ class JsonEncoderTest extends TestCase
             'tset' => 'tset'
         ];
         $json = json_encode($test);
-        $encoder = new \I4code\JaApi\JsonEncoder();
+        $encoder = new JsonEncoder();
         $this->assertSame($test, $encoder->decode($json));
     }
 

--- a/tests/unit/RepositoryTest.php
+++ b/tests/unit/RepositoryTest.php
@@ -1,7 +1,11 @@
 <?php
+declare(strict_types=1);
 
-namespace I4code\JaApi;
+namespace Tests\Unit;
 
+use I4code\JaApi\Factory;
+use I4code\JaApi\Gateway;
+use I4code\JaApi\Repository;
 use PHPUnit\Framework\TestCase;
 
 class RepositoryTest extends TestCase

--- a/tests/unit/ServiceTest.php
+++ b/tests/unit/ServiceTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+namespace Tests\Unit;
+
 use I4code\JaApi\ServerRequestFactory;
 use I4code\JaApi\Service;
 use Nyholm\Psr7\Response;


### PR DESCRIPTION
### Motivation

- Enable PSR-4 autoloading for the test suite so test classes are loaded via Composer rather than manual includes.  
- Bring test files into a consistent `Tests\

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614b636e10832eaa91d4e80b53adcf)